### PR TITLE
Fixed Memory Issues #5

### DIFF
--- a/Ciphers/Symmetric Ciphers/DESEncrypt.c
+++ b/Ciphers/Symmetric Ciphers/DESEncrypt.c
@@ -168,7 +168,7 @@ void processor(char L[ROUNDS+1][SPLITMESSAGELENGTH+1], char R[ROUNDS+1][SPLITMES
 }
 
 
-void encryptor(char *cipherOutput, int verbose, int keysVerbose) {
+void encryptor(char cipherOutput[16+1], int verbose, int keysVerbose) {
     permuteMatrix IPM;
     char keys[ROUNDS+1][PERMUTEDLENGTH+1];
     char L[ROUNDS+1][SPLITMESSAGELENGTH+1], R[ROUNDS+1][SPLITMESSAGELENGTH+1];
@@ -216,11 +216,15 @@ void encryptor(char *cipherOutput, int verbose, int keysVerbose) {
     
     // 🌿 Convert binary Cipher to Hexadecimal Cipher
     binaryKeyToHexadecimalResult(binaryResult, cipherOutput);
+
+    // Freeing 
+    free(binaryMessage);
+    free(binaryMessagePlus);
 }
 
 int main() {
     int verbose =0, keysVerbose=1;
-    char *cipherOutput;
+    char cipherOutput[16+1];
 
     encryptor(cipherOutput, verbose, keysVerbose);
 


### PR DESCRIPTION
- Issue was mostly likely due to uninitialied character pointer variable cipherOutput
- And, not freeing the dynamically allocated binaryMessage and binarMessagePlus Variable

Solution to Issue #5  confirmed with valgrind